### PR TITLE
Reduce the count first

### DIFF
--- a/Source/Fx.CSS3.js
+++ b/Source/Fx.CSS3.js
@@ -354,14 +354,14 @@ provides: [Fx.Tween.CSS3, Fx.Morph.CSS3, Fx.Elements.CSS3]
 			},
 		
 			_complete: function() {
-				if(this.count-- == 0) {
+				if(--this.count == 0) {
 					this.fireEvent('complete', this.subject);
 					if (!this.callChain()) this.fireEvent('chainComplete', this.subject);
 				}
 			},
 		
 			_cancel: function() {
-				if(this.count-- == 0) {
+				if(--this.count == 0) {
 					this.fireEvent('cancel', this.subject);
 					this.clearChain();
 				}


### PR DESCRIPTION
Reduce the count and return the reduced count (instead of return count then reduce), or will never equal 0 and won't fire the event.
