### PR TITLE
Update to current transitionEnd events for IE10+(?) and Firefox

### DIFF
--- a/Source/Fx.CSS3.js
+++ b/Source/Fx.CSS3.js
@@ -75,7 +75,7 @@ provides: [Fx.Tween.CSS3, Fx.Morph.CSS3, Fx.Elements.CSS3]
 				transitionProperty: prefix + 'TransitionProperty',
 				transitionDuration: prefix + 'TransitionDuration',
 				transitionTimingFunction : prefix + 'TransitionTimingFunction',
-				transitionend: (prefix == 'ms' || prefix == 'Moz') ? 'transitionEnd' : prefix + 'TransitionEnd'
+				transitionend: prefix == 'Moz' ? 'transitionend' : (prefix == 'ms' ? 'MS' : prefix) + 'TransitionEnd'
 			}
 		}
 		return false;


### PR DESCRIPTION
Firefox uses transitionend (not transitionEnd). IE10 (at least as of latest dev preview) uses MSTransitionEnd.
https://developer.mozilla.org/en/CSS/CSS_transitions
http://msdn.microsoft.com/en-us/ie/hh272902.aspx#_CSSTransitions
